### PR TITLE
Undefine comparison operators by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MonteCarloMeasurements"
 uuid = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 authors = ["baggepinnen <baggepinnen@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ true
 julia> mean(p) ≈ m
 true
 ```
-`sigmapoints` also accepts a `Normal/MvNormal` object as input.
+`sigmapoints` also accepts a `Normal/MvNormal` object as input. *Caveat:* If you are creating several one-dimensional uncertain values using sigmaopints independently, they will be strongly correlated. Use the multidimensional constructor!
 
 # Latin hypercube sampling
 We do not provide functionality for [latin hypercube sampling](https://en.wikipedia.org/wiki/Latin_hypercube_sampling), rather, we show how to use the package [LatinHypercubeSampling.jl](https://github.com/MrUrq/LatinHypercubeSampling.jl) to initialize particles.
@@ -269,7 +269,7 @@ p = 0 ± 1
 Ideally, half of the particles should turn out negative and half positive when applying `negsquare(p)`. However, this will not happen as the `x > 0` is not defined for uncertain values. To circumvent this, define `negsquare` as a primitive using `register_primitive` described below. Particles will then be propagated one by one through the entire function `negsquare`. Common such functions from `Base`, such as `max/min` etc. are already registered.
 
 Sometimes, defining a primitive function can be difficult, such as when the uncertain parameters are baked into some object. In such cases, we can call the function `unsafe_comparisons(true)`, which defines all comparison operators for uncertain values to compare using the `mean`. Note however that this enabling this is somewhat *unsafe* as this corresponds to a fallback to linear uncertainty propagation, why it's turned off by default. We also provide the macro
-`@unsafe_comparisons ex` to enable mean comparisons only locally in the expression `ex`.
+`@unsafe ex` to enable mean comparisons only locally in the expression `ex`.
 
 # Overloading a new function
 If a method for `Particles` is not implemented for your function `yourfunc`, the pattern looks like this

--- a/examples/autodiff_robust_opt.jl
+++ b/examples/autodiff_robust_opt.jl
@@ -25,7 +25,7 @@ Base.:(*)(p::StaticParticles, d::ForwardDiff.Dual) = StaticParticles(p.particles
 function solvemany()
     algos = [NelderMead(), SimulatedAnnealing(), BFGS(), Newton()]
     map(algos) do algo
-        res = optimize(cost, params, algo, autodiff=:forward)
+        res = Optim.optimize(cost, params, algo, autodiff=:forward)
         m = res.minimizer
         cost(m)
     end

--- a/examples/controlsystems.jl
+++ b/examples/controlsystems.jl
@@ -48,7 +48,7 @@ hline!([0], l=(:dash, :black), primary=false)
 
 # ## Time Simulations
 # We start by sampling the system to obtain a discrete-time model.
-@unsafe_comparisons Pd = c2d(G, 0.1)
+@unsafe Pd = c2d(G, 0.1)
 # We then simulate an plot the results
 y,t,x = step(Pd, 20)
 errorbarplot(t,y[:], 0.00, layout=3, subplot=1, alpha=0.5)

--- a/examples/lhs.jl
+++ b/examples/lhs.jl
@@ -2,7 +2,7 @@
 using MonteCarloMeasurements, LatinHypercubeSampling, Test
 ndims  = 2
 N      = 40   # Number of particles
-ngen   = 1000 # How long to run optimization
+ngen   = 2000 # How long to run optimization
 X, fit = LHCoptim(N,ndims,ngen)
 m, Σ   = [1,2], [2 1; 1 4] # Desired mean and covariance
 particles = transform_moments(X, m, Σ)
@@ -22,6 +22,15 @@ p         = Particles(particles)
 plot(scatter(eachcol(particles)..., title="Sample"), plot(fit, title="Fitness vs. iteration"))
 vline!(particles[:,1]) # First dimension is still latin
 hline!(particles[:,2]) # Second dimension is not
+
+# We provide a method which absolutely preserves the latin property in all dimensions, but if you use this, the covariance of the sample will be slighlty wrong
+particles = transform_moments(X, m, Σ, preserve_latin=true)
+p         = Particles(particles)
+plot(scatter(eachcol(particles)..., title="Sample"), plot(fit, title="Fitness vs. iteration"))
+vline!(particles[:,1]) # First dimension is still latin
+hline!(particles[:,2]) # Second dimension is not
+@test mean(particles, dims=1)[:] ≈ m
+@test cov(particles) ≉ Σ # OBS not the not approx equal!
 
 # We can also visualize the statistics of the sample
 using StatsPlots

--- a/examples/lhs.jl
+++ b/examples/lhs.jl
@@ -15,7 +15,7 @@ vline!(particles[:,1]) # First dimension is still latin
 hline!(particles[:,2]) # Second dimension is not
 
 
-# If we do the same thing with a diagonal covariance matrix, the latin property is preserved in all dimensions.
+# If we do the same thing with a diagonal covariance matrix, the latin property is approximately preserved in all dimensions provided that the latin optimizer was run sufficiently long.
 m, Σ   = [1,2], [2 0; 0 4] # Desired mean and covariance
 particles = transform_moments(X, m, Σ)
 p         = Particles(particles)

--- a/examples/robust_controller_opt.jl
+++ b/examples/robust_controller_opt.jl
@@ -51,3 +51,5 @@ for params = (params, res.minimizer)
 end
 hline!([Msc], l=(:black, :dash), subplot=2)
 fig
+
+# Other things that could potentially be relevant is adding a probabilistic constraint on the time-domain output, such as the probability of having the step response go above 1.5 must be < 0.05 etc.

--- a/examples/robust_controller_opt.jl
+++ b/examples/robust_controller_opt.jl
@@ -18,7 +18,7 @@ function cost(params)
     S = 1/(1 + P*C)   # Sensitivity function
     local Gd
     try
-        Gd = c2d(G,0.1) # Discretize the system. This might fail for some parameters, so we catch these cases and return a high value
+        @unsafe_comparisons Gd = c2d(G,0.1) # Discretize the system. This might fail for some parameters, so we catch these cases and return a high value
     catch
         return 1000
     end
@@ -42,7 +42,7 @@ for params = (params, res.minimizer)
     C  = pid(kp =kp,ki =ki,kd =kd)
     G  = feedback(P*C)
     S  = 1/(1 + P*C)
-    Gd = c2d(G,0.1)
+    @unsafe_comparisons Gd = c2d(G,0.1)
     y,t,_ = step(Gd,15)
     y     = y[:]
     mag   = bode(S, w)[1][:]

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -1,7 +1,56 @@
 module MonteCarloMeasurements
+using LinearAlgebra, Statistics, Random, StaticArrays, RecipesBase, GenericLinearAlgebra, MacroTools
+using Distributed: pmap
+import StatsBase: ProbabilityWeights
+using Lazy: @forward
+import Base: add_sum
+
+using Distributions, StatsBase
+
 
 const DEFAUL_NUM_PARTICLES = 500
 const DEFAUL_STATIC_NUM_PARTICLES = 100
+
+const COMPARISON_FUNCTION = Ref{Function}(mean)
+const USE_UNSAFE_COMPARIONS = Ref(false)
+
+"""
+    unsafe_comparisons(onoff=true; verbose=true)
+Toggle the use of a comparison function without warning. By default `mean` is used to reduce particles to a floating point number for comparisons. This function can be changed, example: `set_comparison_function(median)`
+"""
+function unsafe_comparisons(onoff=true; verbose=true)
+    USE_UNSAFE_COMPARIONS[] = onoff
+    if onoff && verbose
+        @info "Unsafe comparisons using the function $(COMPARISON_FUNCTION[]) has been enabled globally. Use `@unsafe_comparisons` to enable in a local expression only or `unsafe_comparisons(false)` to turn off unsafe comparisons"
+    end
+end
+"""
+    set_comparison_function(f)
+
+Change the Function used to reduce particles to a number for comparison operators
+Toggle the use of a comparison Function without warning using the Function `unsafe_comparisons`.
+"""
+function set_comparison_function(f)
+    COMPARISON_FUNCTION[] = f
+end
+# TODO: have to figure out if new bindings are created in ex and if so, declare them local outside the try block
+using Base.Cartesian: @nexprs
+macro unsafe_comparisons(ex)
+    @capture(ex, assigned_vars__ = y_)
+    n = length(assigned_vars)
+    quote
+        previous_state = USE_UNSAFE_COMPARIONS[]
+        unsafe_comparisons(true, verbose=false)
+        @nexprs $n j->(local $(esc(assigned_vars[j])))
+        local res
+        try
+            res = ($(esc(ex)))
+        finally
+            unsafe_comparisons(previous_state, verbose=false)
+        end
+        res
+    end
+end
 
 export AbstractParticles,Particles,StaticParticles, WeightedParticles, sigmapoints, transform_moments, ≲,≳, systematic_sample, outer_product, meanstd, meanvar, register_primitive, register_primitive_multi, register_primitive_single, ℝⁿ2ℝⁿ_function, ℂ2ℂ_function, resample!, @bymap, @bypmap
 # Plot exports
@@ -12,16 +61,9 @@ export mean, std, cov, var, quantile, median
 # Distributions reexport
 export Normal, MvNormal, Cauchy, Beta, Exponential, Gamma, Laplace, Uniform, fit, logpdf
 
+export unsafe_comparisons, @unsafe_comparisons, set_comparison_function
 
-import Base: add_sum
 
-
-using LinearAlgebra, Statistics, Random, StaticArrays, RecipesBase, GenericLinearAlgebra, MacroTools
-using Distributed: pmap
-import StatsBase: ProbabilityWeights
-using Lazy: @forward
-
-using Distributions, StatsBase
 
 include("types.jl")
 include("register_primitive.jl")
@@ -37,5 +79,4 @@ include("optimize.jl")
 end
 
 
-# TODO: Mutation, test on ControlSystems
 # TODO: ifelse?

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -21,7 +21,7 @@ Toggle the use of a comparison function without warning. By default `mean` is us
 function unsafe_comparisons(onoff=true; verbose=true)
     USE_UNSAFE_COMPARIONS[] = onoff
     if onoff && verbose
-        @info "Unsafe comparisons using the function $(COMPARISON_FUNCTION[]) has been enabled globally. Use `@unsafe_comparisons` to enable in a local expression only or `unsafe_comparisons(false)` to turn off unsafe comparisons"
+        @info "Unsafe comparisons using the function $(COMPARISON_FUNCTION[]) has been enabled globally. Use `@unsafe` to enable in a local expression only or `unsafe_comparisons(false)` to turn off unsafe comparisons"
     end
 end
 """
@@ -34,7 +34,11 @@ function set_comparison_function(f)
     COMPARISON_FUNCTION[] = f
 end
 
-macro unsafe_comparisons(ex)
+"""
+    @unsafe expression
+Activates unsafe comparisons for the provided expression only. The expression is surrounded by a try/catch block to robustly restore unsafe comparisons in case of exception.
+"""
+macro unsafe(ex)
     ex2 = if @capture(ex, assigned_vars__ = y_)
         if length(assigned_vars) == 1
             esc(assigned_vars[1])
@@ -66,7 +70,7 @@ export mean, std, cov, var, quantile, median
 # Distributions reexport
 export Normal, MvNormal, Cauchy, Beta, Exponential, Gamma, Laplace, Uniform, fit, logpdf
 
-export unsafe_comparisons, @unsafe_comparisons, set_comparison_function
+export unsafe_comparisons, @unsafe, set_comparison_function
 
 
 

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -21,7 +21,7 @@ Toggle the use of a comparison function without warning. By default `mean` is us
 function unsafe_comparisons(onoff=true; verbose=true)
     USE_UNSAFE_COMPARIONS[] = onoff
     if onoff && verbose
-        @info "Unsafe comparisons using the function $(COMPARISON_FUNCTION[]) has been enabled globally. Use `@unsafe` to enable in a local expression only or `unsafe_comparisons(false)` to turn off unsafe comparisons"
+        @info "Unsafe comparisons using the function `$(COMPARISON_FUNCTION[])` has been enabled globally. Use `@unsafe` to enable in a local expression only or `unsafe_comparisons(false)` to turn off unsafe comparisons"
     end
 end
 """

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -50,9 +50,17 @@ end
 shortform(p::Particles) = "Part"
 shortform(p::StaticParticles) = "SPart"
 shortform(p::WeightedParticles) = "WPart"
+function to_num_str(p)
+    s = std(p)
+    if s < eps(p)
+        string(round(mean(p), sigdigits=3))
+    else
+        string(round(mean(p), sigdigits=3), " ± ", round(s, sigdigits=2))
+    end
+end
 function Base.show(io::IO, p::AbstractParticles{T,N}) where {T,N}
     sPT = shortform(p)
-    print(io, "$(sPT){$N}(", round(mean(p), sigdigits=3), " ± ", round(std(p), sigdigits=3),")")
+    print(io, "$(sPT)$N(", to_num_str(p),")")
 end
 # function Base.show(io::IO, p::MvParticles)
 #     sPT = shortform(p)
@@ -69,7 +77,7 @@ end
 
 # Two-argument functions
 foreach(register_primitive_multi, [+,-,*,/,//,^,
-max,min,minmax,mod,mod1,atan,atand,add_sum,hypot])
+max,min,mod,mod1,atan,atand,add_sum,hypot])
 # One-argument functions
 foreach(register_primitive_single, [*,+,-,/,
 exp,exp2,exp10,expm1,
@@ -131,7 +139,7 @@ for PT in (:WeightedParticles,)
         end
     end
     # Two-argument functions
-    for ff in (+,-,*,/,//,^, max,min,minmax,mod,mod1,atan,add_sum)
+    for ff in (+,-,*,/,//,^, max,min,mod,mod1,atan,add_sum)
         f = nameof(ff)
         @eval begin
             function (Base.$f)(p::$PT{T,N},a::Real...) where {T,N}
@@ -334,6 +342,7 @@ Base.:≉(a,b::AbstractParticles,lim=2) = !(≈(a,b,lim))
 Base.:≉(a::AbstractParticles,b,lim=2) = !(≈(a,b,lim))
 Base.:≉(a::AbstractParticles,b::AbstractParticles,lim=2) = !(≈(a,b,lim))
 
+Base.minmax(x::AbstractParticles,y::AbstractParticles) = (min(x,y), max(x,y))
 
 Base.:!(p::AbstractParticles) = all(p.particles .== 0)
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -47,12 +47,15 @@ function print_functions_to_extend()
         end
     end
 end
+shortform(p::Particles) = "Part"
+shortform(p::StaticParticles) = "SPart"
+shortform(p::WeightedParticles) = "WPart"
 function Base.show(io::IO, p::AbstractParticles{T,N}) where {T,N}
-    sPT = string(typeof(p).name)
-    print(io, "(", N, " $sPT: ", round(mean(p), sigdigits=3), " ± ", round(std(p), sigdigits=3),")")
+    sPT = shortform(p)
+    print(io, "($(sPT){$N}: ", round(mean(p), sigdigits=3), " ± ", round(std(p), sigdigits=3),")")
 end
 # function Base.show(io::IO, p::MvParticles)
-#     sPT = string(typeof(p).name)
+#     sPT = shortform(p)
 #     print(io, "(", N, " $sPT with mean ", round.(mean(p), sigdigits=3), " and std ", round.(sqrt.(diag(cov(p))), sigdigits=3),")")
 # end
 for mime in (MIME"text/x-tex", MIME"text/x-latex")

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -308,6 +308,7 @@ Base.:!(p::AbstractParticles) = all(p.particles .== 0)
 
 Base.isinteger(p::AbstractParticles) = all(isinteger, p.particles)
 Base.iszero(p::AbstractParticles) = all(iszero, p.particles)
+Base.iszero(p::AbstractParticles, tol) = abs(mean(p.particles)) < tol
 
 
 ≲(a::Real,p::AbstractParticles,lim=2) = (mean(p)-a)/std(p) > lim

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -52,7 +52,7 @@ shortform(p::StaticParticles) = "SPart"
 shortform(p::WeightedParticles) = "WPart"
 function Base.show(io::IO, p::AbstractParticles{T,N}) where {T,N}
     sPT = shortform(p)
-    print(io, "($(sPT){$N}: ", round(mean(p), sigdigits=3), " ± ", round(std(p), sigdigits=3),")")
+    print(io, "$(sPT){$N}(", round(mean(p), sigdigits=3), " ± ", round(std(p), sigdigits=3),")")
 end
 # function Base.show(io::IO, p::MvParticles)
 #     sPT = shortform(p)

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -58,9 +58,13 @@ function to_num_str(p)
         string(round(mean(p), sigdigits=3), " ± ", round(s, sigdigits=2))
     end
 end
-function Base.show(io::IO, p::AbstractParticles{T,N}) where {T,N}
+function Base.show(io::IO, ::MIME"text/plain", p::AbstractParticles{T,N}) where {T,N}
     sPT = shortform(p)
     print(io, "$(sPT)$N(", to_num_str(p),")")
+end
+
+function Base.show(io::IO, p::AbstractParticles{T,N}) where {T,N}
+    print(io, to_num_str(p))
 end
 # function Base.show(io::IO, p::MvParticles)
 #     sPT = shortform(p)
@@ -68,9 +72,7 @@ end
 # end
 for mime in (MIME"text/x-tex", MIME"text/x-latex")
     @eval function Base.show(io::IO, ::$mime, p::AbstractParticles)
-        print(io, "\$")
-        show(io, p)
-        print("\$")
+        print(io, "\$"); show(io, p); print("\$")
     end
 end
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -380,5 +380,17 @@ function ℝⁿ2ℝⁿ_function(f::F, p::AbstractArray{T}) where {F,T<:AbstractP
     reshape(out, size(p))
 end
 
+function ℝⁿ2ℝⁿ_function(f::F, p::AbstractArray{T}, p2::AbstractArray{T}) where {F,T<:AbstractParticles}
+    individuals = map(1:length(p[1])) do i
+        f(getindex.(p,i), getindex.(p2,i))
+    end
+    out = similar(p)
+    for i = 1:length(p)
+        out[i] = T(getindex.(individuals,i))
+    end
+    reshape(out, size(p))
+end
+
 
 Base.exp(p::AbstractMatrix{<:AbstractParticles}) = ℝⁿ2ℝⁿ_function(exp, p)
+LinearAlgebra.lyap(p1::Matrix{<:AbstractParticles}, p2::Matrix{<:AbstractParticles}) = ℝⁿ2ℝⁿ_function(lyap, p1, p2)

--- a/src/sigmapoints.jl
+++ b/src/sigmapoints.jl
@@ -33,7 +33,7 @@ sigmapoints(d::MvNormal) = sigmapoints(mean(d), Matrix(cov(d)))
 
 
 """
-    Y = transform_moments(X::Matrix, m, Σ)
+    Y = transform_moments(X::Matrix, m, Σ; preserve_latin=false)
 Transforms `X` such that it get the specified mean and covariance.
 
 ```julia
@@ -43,9 +43,15 @@ julia> cov(particles) ≈ Σ
 true
 ```
 **Note**, if `X` is a latin hypercube and `Σ` is non-diagonal, then the latin property is destroyed for all dimensions but the first.
+We provide a method `preserve_latin=true`) which absolutely preserves the latin property in all dimensions, but if you use this, the covariance of the sample will be slightly wrong
 """
-function transform_moments(X,m,Σ)
+function transform_moments(X,m,Σ; preserve_latin=false)
     X  = X .- mean(X,dims=1) # Normalize the sample
-    xl = cholesky(cov(X)).L
+    if preserve_latin
+        xl = Diagonal(std(X,dims=1)[:])
+        # xl = cholesky(Diagonal(var(X,dims=1)[:])).L
+    else
+        xl = cholesky(cov(X)).L
+    end
     Matrix((m .+ (cholesky(Σ).L/xl)*X')')
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ Random.seed!(0)
             @testset "$(repr(PT))" begin
                 @info "Running tests for $PT"
                 p = PT(100)
+                @test_nowarn println(p)
                 @test (p+p+p).particles ≈ 3p.particles # Test 3arg operator
                 @test (p+p+1).particles ≈ 1 .+ 2p.particles # Test 3arg operator
                 @test (1+p+1).particles ≈ 2 .+ p.particles # Test 3arg operator
@@ -48,6 +49,7 @@ Random.seed!(0)
                 @test var(p) ≈ 1 atol=0.2
                 @test meanvar(p) ≈ 1/(length(p)) atol=5e-3
                 @test meanstd(p) ≈ 1/sqrt(length(p)) atol=5e-3
+                @test minmax(1+p,p) == (p, 1+p)
 
                 @test !(p ≲ p)
                 @test !(p ≳ p)
@@ -77,6 +79,7 @@ Random.seed!(0)
                     @test_throws ErrorException p>=p
                     @test_throws ErrorException p<=p
                     @unsafe begin
+                        @test -10 < p
                         @test p <= p
                         @test p >= p
                         @test !(p < p)
@@ -265,8 +268,10 @@ Random.seed!(0)
         p = 0 ± 1
         @test p[1] == p.particles[1]
         @test_nowarn display(p)
-        @test_nowarn show(p)
-        @test_nowarn show(stdout, MIME"text/x-latex"(), p)
+        @test_nowarn println(p)
+        @test_nowarn println(stdout, MIME"text/x-latex"(), p)
+        @test_nowarn println(0p)
+        @test_nowarn println(stdout, MIME"text/x-latex"(), 0p)
         @test Particles{Float64,500}(p) == p
         @test Particles{Float64,5}(0) == 0*Particles(5)
         @test length(Particles(100, MvNormal(2,1))) == 2
@@ -287,9 +292,9 @@ Random.seed!(0)
         @test_throws ArgumentError AbstractFloat(p)
         @test AbstractFloat(0p) == 0.0
         @test Particles(500) + Particles(randn(Float32, 500)) isa typeof(Particles(500))
-        @test_nowarn sqrt(complex(p,p)) == 1
         @test isfinite(p)
         @test iszero(0p)
+        @test iszero(p, 0.1)
         @test !iszero(p)
         @test !(!p)
         @test !(0p)
@@ -311,6 +316,11 @@ Random.seed!(0)
         @test intersect(p,p) == union(p,p)
         @test length(intersect(p, 1+p)) < 2length(p)
         @test length(union(p, 1+p)) == 2length(p)
+
+        p = 2 ± 0
+        q = 3 ± 0
+        @test sqrt(complex(p,p)) == sqrt(complex(2,2))
+        @test complex(p,p)/complex(q,q) == complex(2,2)/complex(3,3)
     end
 
     @time @testset "mutation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -269,9 +269,14 @@ Random.seed!(0)
         @test p[1] == p.particles[1]
         @test_nowarn display(p)
         @test_nowarn println(p)
-        @test_nowarn println(stdout, MIME"text/x-latex"(), p)
+        @test_nowarn show(stdout, MIME"text/x-latex"(), p); println()
         @test_nowarn println(0p)
-        @test_nowarn println(stdout, MIME"text/x-latex"(), 0p)
+        @test_nowarn show(stdout, MIME"text/x-latex"(), 0p); println()
+
+        @test_nowarn display([p, p])
+        @test_nowarn println([p, p])
+        @test_nowarn println([p, 0p])
+
         @test Particles{Float64,500}(p) == p
         @test Particles{Float64,5}(0) == 0*Particles(5)
         @test length(Particles(100, MvNormal(2,1))) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,12 +71,12 @@ Random.seed!(0)
                 @test p ≉ 2.1std(p)
                 @test !(p ≉ 1.9std(p))
 
-                @testset "mean comparisons" begin
+                @testset "unsafe comparisons" begin
                     @test_throws ErrorException p<p
                     @test_throws ErrorException p>p
                     @test_throws ErrorException p>=p
                     @test_throws ErrorException p<=p
-                    MonteCarloMeasurements.@unsafe_comparisons begin
+                    @unsafe_comparisons begin
                         @test p <= p
                         @test p >= p
                         @test !(p < p)
@@ -86,8 +86,15 @@ Random.seed!(0)
                     end
                     @test_throws ErrorException p<p
                     @test_throws ErrorException p>p
+                    @test_throws ErrorException @unsafe_comparisons error("") # Should still be safe after error
                     @test_throws ErrorException p>=p
                     @test_throws ErrorException p<=p
+                    @unsafe_comparisons testvar = 2
+                    @test testvar == 2
+                    @unsafe_comparisons testvar1,testvar2 = 1,2
+                    @test (testvar1,testvar2) == (1,2)
+                    # TODO, test more complicated RHS
+                    # TODO, test changing comparison function
                 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -305,6 +305,9 @@ Random.seed!(0)
         B = A .± 0
         @test sum(mean, exp(A) .- exp(B)) < 1e-9
 
+        pp = [1. 0; 0 1] .± 0.0
+        @test lyap(pp,pp) == lyap([1. 0; 0 1],[1. 0; 0 1])
+
         @test intersect(p,p) == union(p,p)
         @test length(intersect(p, 1+p)) < 2length(p)
         @test length(union(p, 1+p)) == 2length(p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,12 +48,7 @@ Random.seed!(0)
                 @test var(p) ≈ 1 atol=0.2
                 @test meanvar(p) ≈ 1/(length(p)) atol=5e-3
                 @test meanstd(p) ≈ 1/sqrt(length(p)) atol=5e-3
-                @test p <= p
-                @test p >= p
-                @test !(p < p)
-                @test !(p > p)
-                @test (p < 1+p)
-                @test (p+1 > p)
+
                 @test !(p ≲ p)
                 @test !(p ≳ p)
                 @test (p ≲ 2.1)
@@ -76,10 +71,29 @@ Random.seed!(0)
                 @test p ≉ 2.1std(p)
                 @test !(p ≉ 1.9std(p))
 
+                @testset "mean comparisons" begin
+                    @test_throws ErrorException p<p
+                    @test_throws ErrorException p>p
+                    @test_throws ErrorException p>=p
+                    @test_throws ErrorException p<=p
+                    MonteCarloMeasurements.@unsafe_comparisons begin
+                        @test p <= p
+                        @test p >= p
+                        @test !(p < p)
+                        @test !(p > p)
+                        @test (p < 1+p)
+                        @test (p+1 > p)
+                    end
+                    @test_throws ErrorException p<p
+                    @test_throws ErrorException p>p
+                    @test_throws ErrorException p>=p
+                    @test_throws ErrorException p<=p
+                end
+
 
                 f = x -> 2x + 10
                 @test 9.6 < mean(f(p)) < 10.4
-                @test 9.6 < f(p) < 10.4
+                # @test 9.6 < f(p) < 10.4
                 @test f(p) ≈ 10
                 @test !(f(p) ≲ 11)
                 @test f(p) ≲ 15
@@ -105,7 +119,7 @@ Random.seed!(0)
                 @test all(A*b .≈ [0,0,0])
 
                 @test all(A\b .≈ zeros(3))
-                @test_nowarn qr(A)
+                @test_nowarn @unsafe_comparisons qr(A)
                 @test_nowarn Particles(100, MvNormal(2,1)) ./ Particles(100, Normal(2,1))
                 pn = Particles(100, Normal(2,1), systematic=false)
                 @test pn ≈ 2
@@ -272,7 +286,7 @@ Random.seed!(0)
         @test eps(p) == eps(Float64)
         A = randn(2,2)
         B = A .± 0
-        @test sum(abs, exp(A) .- exp(B)) < 1e-9
+        @test sum(mean, exp(A) .- exp(B)) < 1e-9
 
         @test intersect(p,p) == union(p,p)
         @test length(intersect(p, 1+p)) < 2length(p)
@@ -411,7 +425,7 @@ Random.seed!(0)
 
         h(x,y) = x .* y'
         Base.Cartesian.@nextract 4 p d-> 0±1
-        @test_broken h([p_1,p_2], [p_3,p_4]) ≈ @bymap  h([p_1,p_2], [p_3,p_4])
+        @test_broken h([p_1,p_2], [p_3,p_4]) ≈ @bymap h([p_1,p_2], [p_3,p_4])
         @test_broken h([p_1,p_2], [p_3,p_4]) ≈ @bypmap h([p_1,p_2], [p_3,p_4])
 
         h2(x,y) = x .* y


### PR DESCRIPTION
This is a breaking change. This makes all use of comparison operators (`<,>,<=` etc.) throw an error since they are really poorly defined for uncertain values. The old behavior can be reenabled by `unsafe_comparisons(true)`
Also:
- Improve printing 
- Some new functions