### PR TITLE
Remove support for WeightedParticles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MonteCarloMeasurements"
 uuid = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 authors = ["baggepinnen <baggepinnen@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MonteCarloMeasurements"
 uuid = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 authors = ["baggepinnen <baggepinnen@gmail.com>"]
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ One can also call (`Particles/StaticParticles`)
 - `Particles(v::Vector)` pre-sampled particles
 - `Particles(N = 500, d::Distribution = Normal(0,1))` samples `N` particles from the distribution `d`.
 - The ± operator (`\pm`) (similar to [Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl)). We have `μ ± σ = μ + σ*Particles(DEFAUL_NUM_PARTICLES)`, where the global constant `DEFAUL_NUM_PARTICLES = 500`. You can change this if you would like, or simply define your own `±` operator like `±(μ,σ) = μ + σ*Particles(my_default_number, my_default_distribution)`. The upside-down operator ∓ (`\mp`) instead creates a `StaticParticles(100)`.
-- The `..` binary infix operator creates uniformly sampled particles, e.g., `2..3 = Particles(Uniform(2,3))` 
+- The `..` binary infix operator creates uniformly sampled particles, e.g., `2..3 = Particles(Uniform(2,3))`
 
 **Common univariate distributions are sampled systematically**, meaning that a single random number is drawn and used to seed the sample. This will reduce the variance of the sample. If this is not desired, call `Particles(N, [d]; systematic=false)` The systematic sample can maintain its originally sorted order by calling `Particles(N, permute=false)`, but the default is to permute the sample so as to not have different `Particles` correlate strongly with each other.
 
@@ -179,7 +179,7 @@ true
 julia> mean(p) ≈ m
 true
 ```
-`sigmapoints` also accepts a `Normal/MvNormal` object as input. *Caveat:* If you are creating several one-dimensional uncertain values using sigmaopints independently, they will be strongly correlated. Use the multidimensional constructor! Example:
+`sigmapoints` also accepts a `Normal/MvNormal` object as input. *Caveat:* If you are creating several one-dimensional uncertain values using sigmapoints independently, they will be strongly correlated. Use the multidimensional constructor! Example:
 ```julia
 p = StaticParticles(sigmapoints(1, 0.1^2))               # Wrong!
 ζ = StaticParticles(sigmapoints(0.3, 0.1^2))             # Wrong!
@@ -384,13 +384,6 @@ We also provide in-place versions of the above functions, e.g.,
 - `sqrt!(out, p)`, `exp!(out, p)`, `sin!(out, p)`, `cos!(out, p)`
 
 The function `ℂ2ℂ_function(f::Function, z)` (`ℂ2ℂ_function!(f::Function, out, z)`) applies `f : ℂ → ℂ ` to `z::Complex{<:AbstractParticles}`.
-
-# Weighted particles
-The type `WeightedParticles` contains an additional field `logweights`. You may modify this field as you see fit, e.g.
-```julia
-reweight(p,y) = (p.logweights .+= logpdf.(Normal(0,1), y .- p.particles))
-```
-where `y` would be some measurement. After this you can resample the particles using `resample!(p)`. This performs a systematic resample with replacement, where each particle is sampled proportionally to `exp.(logweights)`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ One can also call (`Particles/StaticParticles`)
 - `Particles(v::Vector)` pre-sampled particles
 - `Particles(N = 500, d::Distribution = Normal(0,1))` samples `N` particles from the distribution `d`.
 - The ± operator (`\pm`) (similar to [Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl)). We have `μ ± σ = μ + σ*Particles(DEFAUL_NUM_PARTICLES)`, where the global constant `DEFAUL_NUM_PARTICLES = 500`. You can change this if you would like, or simply define your own `±` operator like `±(μ,σ) = μ + σ*Particles(my_default_number, my_default_distribution)`. The upside-down operator ∓ (`\mp`) instead creates a `StaticParticles(100)`.
+- The `..` binary infix operator creates uniformly sampled particles, e.g., `2..3 = Particles(Uniform(2,3))` 
 
 **Common univariate distributions are sampled systematically**, meaning that a single random number is drawn and used to seed the sample. This will reduce the variance of the sample. If this is not desired, call `Particles(N, [d]; systematic=false)` The systematic sample can maintain its originally sorted order by calling `Particles(N, permute=false)`, but the default is to permute the sample so as to not have different `Particles` correlate strongly with each other.
 

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -61,7 +61,7 @@ macro unsafe(ex)
     end
 end
 
-export ±, ∓, AbstractParticles,Particles,StaticParticles, WeightedParticles, sigmapoints, transform_moments, ≲,≳, systematic_sample, outer_product, meanstd, meanvar, register_primitive, register_primitive_multi, register_primitive_single, ℝⁿ2ℝⁿ_function, ℂ2ℂ_function, ℂ2ℂ_function!, resample!, bootstrap, sqrt!, exp!, sin!, cos!, wasserstein
+export ±, ∓, .., AbstractParticles,Particles,StaticParticles, WeightedParticles, sigmapoints, transform_moments, ≲,≳, systematic_sample, outer_product, meanstd, meanvar, register_primitive, register_primitive_multi, register_primitive_single, ℝⁿ2ℝⁿ_function, ℂ2ℂ_function, ℂ2ℂ_function!, resample!, bootstrap, sqrt!, exp!, sin!, cos!, wasserstein
 # Plot exports
 export errorbarplot, mcplot, ribbonplot
 

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -1,7 +1,6 @@
 module MonteCarloMeasurements
 using LinearAlgebra, Statistics, Random, StaticArrays, RecipesBase, GenericLinearAlgebra, MacroTools
 using Distributed: pmap
-import StatsBase: ProbabilityWeights
 using Lazy: @forward
 import Base: add_sum
 
@@ -61,7 +60,7 @@ macro unsafe(ex)
     end
 end
 
-export ±, ∓, .., AbstractParticles,Particles,StaticParticles, WeightedParticles, sigmapoints, transform_moments, ≲,≳, systematic_sample, outer_product, meanstd, meanvar, register_primitive, register_primitive_multi, register_primitive_single, ℝⁿ2ℝⁿ_function, ℂ2ℂ_function, ℂ2ℂ_function!, resample!, bootstrap, sqrt!, exp!, sin!, cos!, wasserstein
+export ±, ∓, .., AbstractParticles,Particles,StaticParticles, sigmapoints, transform_moments, ≲,≳, systematic_sample, outer_product, meanstd, meanvar, register_primitive, register_primitive_multi, register_primitive_single, ℝⁿ2ℝⁿ_function, ℂ2ℂ_function, ℂ2ℂ_function!, resample!, bootstrap, sqrt!, exp!, sin!, cos!, wasserstein
 # Plot exports
 export errorbarplot, mcplot, ribbonplot
 
@@ -97,6 +96,3 @@ function __init__()
 end
 
 end
-
-
-# TODO: ifelse?

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -9,6 +9,8 @@ If `μ` is a vector, the constructor `MvNormal` is used, and `σ` is thus treate
 ∓(μ::Real,σ) = μ + σ*StaticParticles(DEFAUL_STATIC_NUM_PARTICLES)
 ∓(μ::AbstractVector,σ) = StaticParticles(DEFAUL_STATIC_NUM_PARTICLES, MvNormal(μ, σ))
 
+(..)(a,b) = Particles(DEFAUL_NUM_PARTICLES, Uniform(a,b))
+
 """
     ⊗(μ,σ) = outer_product(Normal.(μ,σ))
 
@@ -205,6 +207,14 @@ for PT in (:WeightedParticles,)
     @eval Statistics.cov(p::$PT,args...;kwargs...) = var(p,args...;kwargs...)
 end
 
+function Particles(d::Distribution;kwargs...)
+    Particles(DEFAUL_NUM_PARTICLES, d; kwargs...)
+end
+
+function StaticParticles(d::Distribution;kwargs...)
+    StaticParticles(DEFAUL_STATIC_NUM_PARTICLES, d; kwargs...)
+end
+
 for PT in (:Particles, :StaticParticles, :WeightedParticles)
     @forward @eval($PT).particles Base.iterate, Base.extrema, Base.minimum, Base.maximum
 
@@ -225,6 +235,8 @@ for PT in (:Particles, :StaticParticles, :WeightedParticles)
             end
             $PT{eltype(v),N}(v)
         end
+
+
 
         function $PT(N::Integer, d::MultivariateDistribution)
             v = rand(d,N)' |> copy # For cache locality

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -60,7 +60,6 @@ Return a short string describing the type
 """
 shortform(p::Particles) = "Part"
 shortform(p::StaticParticles) = "SPart"
-shortform(p::WeightedParticles) = "WPart"
 function to_num_str(p, d=3)
     s = std(p)
     if s < eps(p)
@@ -148,65 +147,6 @@ for PT in (:Particles, :StaticParticles)
     @forward @eval($PT).particles Statistics.mean, Statistics.cov, Statistics.median, Statistics.quantile, Statistics.middle
 end
 
-for PT in (:WeightedParticles,)
-    # Constructors
-    @eval begin
-        $PT(v::Vector, w=fill(-log(length(v)), length(v))) = $PT{eltype(v),length(v)}(v,w)
-        function $PT{T,N}(n::Real) where {T,N} # This constructor is potentially dangerous, replace with convert?
-            v = fill(n,N)
-            w = fill(-log(N),N)
-            $PT{T,N}(v,w)
-        end
-    end
-    # Two-argument functions
-    for ff in (+,-,*,/,//,^, max,min,mod,mod1,atan,add_sum)
-        f = nameof(ff)
-        @eval begin
-            function (Base.$f)(p::$PT{T,N},a::Real...) where {T,N}
-                # $PT{T,N}(map(x->$f(x,a...), p.particles),p.logweights)
-                $PT{T,N}($f.(p.particles, maybe_particles.(a)...), .+(p.logweights, maybe_logweights.(a)...))
-            end
-            function (Base.$f)(a::Real,p::$PT{T,N}) where {T,N}
-                $PT{T,N}(map(x->$f(a,x), p.particles),p.logweights)
-            end
-            function (Base.$f)(p1::$PT{T,N},p2::$PT{T,N}) where {T,N} # TODO: add logweights for multiplication but not for addition
-                sf = string($f)
-                $f == Base.:(*) || @warn("p1 $sf p2 not yet fully supported for WeightedParticles")
-                $PT{T,N}(map($f, p1.particles, p2.particles),p1.logweights+p2.logweights)
-            end
-            function (Base.$f)(p1::$PT{T,N},p2::$PT{S,N}) where {T,S,N} # Needed for particles of different float types :/
-                $PT{promote_type(T,S),N}(map($f, p1.particles, p2.particles),p1.logweights+p2.logweights)
-            end
-        end
-    end
-    # One-argument functions
-    for ff in [*,+,-,/,
-        exp,exp2,exp10,expm1,
-        log,log10,log2,log1p,
-        sin,cos,tan,sind,cosd,tand,sinh,cosh,tanh,
-        asin,acos,atan,asind,acosd,atand,asinh,acosh,atanh,
-        zero,sign,abs,sqrt,rad2deg,deg2rad]
-        f = nameof(ff)
-        @eval function (Base.$f)(p::$PT)
-            $PT(map($f, p.particles), p.logweights)
-        end
-    end
-    for ff in [mean, median, quantile]
-        f = nameof(ff)
-        @eval function (Statistics.$f)(p::$PT,args...;kwargs...)
-            $f(p.particles, Weights(exp.(p.logweights)), args...;kwargs...)
-        end
-    end
-    for ff in [var, std]
-        f = nameof(ff)
-        @eval function (Statistics.$f)(p::$PT{T,N},args...;kwargs...) where {T,N}
-            N == 1 && (return zero(T))
-            $f(p.particles, AnalyticWeights(exp.(p.logweights)), args...;kwargs...)
-        end
-    end
-    @eval Statistics.cov(p::$PT,args...;kwargs...) = var(p,args...;kwargs...)
-end
-
 function Particles(d::Distribution;kwargs...)
     Particles(DEFAUL_NUM_PARTICLES, d; kwargs...)
 end
@@ -215,7 +155,7 @@ function StaticParticles(d::Distribution;kwargs...)
     StaticParticles(DEFAUL_STATIC_NUM_PARTICLES, d; kwargs...)
 end
 
-for PT in (:Particles, :StaticParticles, :WeightedParticles)
+for PT in (:Particles, :StaticParticles)
     @forward @eval($PT).particles Base.iterate, Base.extrema, Base.minimum, Base.maximum
 
     @eval begin
@@ -332,15 +272,7 @@ Statistics.mean(v::MvParticles) = mean.(v)
 Statistics.cov(v::MvParticles,args...;kwargs...) = cov(Matrix(v), args...; kwargs...)
 Distributions.fit(d::Type{<:MultivariateDistribution}, p::MvParticles) = fit(d,Matrix(p)')
 Distributions.fit(d::Type{<:Distribution}, p::AbstractParticles) = fit(d,p.particles)
-check_similar_weights(v) = all(v[i].logweights ≈ v[1].logweights for i in 2:length(v))
-function Statistics.cov(v::MvWParticles,args...;kwargs...)
-    check_similar_weights(v)
-    cov(Matrix(v), AnalyticWeights(v[1].logweights); kwargs...)
-end
-Distributions.fit(d::Type{<:MultivariateDistribution}, p::MvWParticles) = error("Not implemented for weighted particles yet")
-Distributions.fit(d::Type{<:Distribution}, p::WeightedParticles) = error("Not implemented for weighted particles yet")
-Distributions.fit(d::Type{<:MvNormal}, p::MvWParticles) = MvNormal(p)
-Distributions.fit(d::Type{<:Normal}, p::WeightedParticles) = Normal(p)
+
 Distributions.Normal(p::AbstractParticles) = Normal(mean(p), std(p))
 Distributions.MvNormal(p::AbstractParticles) = MvNormal(mean(p), cov(p))
 Distributions.MvNormal(p::MvParticles) = MvNormal(mean(p), cov(p))

--- a/src/register_primitive.jl
+++ b/src/register_primitive.jl
@@ -1,7 +1,5 @@
 @inline maybe_particles(x) = x
 @inline maybe_particles(p::AbstractParticles) = p.particles
-@inline maybe_logweights(x) = 0
-@inline maybe_logweights(p::WeightedParticles) = p.logweights
 
 function register_primitive(ff, eval=eval)
     register_primitive_multi(ff, eval)

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1,20 +1,20 @@
-"""
-    logΣexp, Σexp = logsumexp!(p::WeightedParticles)
-Return log(∑exp(w)). Modifies the weight vector to `w = exp(w-offset)`
-Uses a numerically stable algorithm with offset to control for overflow and `log1p` to control for underflow. `Σexp` is the sum of the weifhts in the state they are left, i.e., `sum(exp.(w).-offset)`.
-
-References:
-https://arxiv.org/pdf/1412.8695.pdf eq 3.8 for p(y)
-https://discourse.julialang.org/t/fast-logsumexp/22827/7?u=baggepinnen for stable logsumexp
-"""
-function logsumexp!(p::WeightedParticles)
-    N = length(p)
-    w = p.logweights
-    offset, maxind = findmax(w)
-    w .= exp.(w .- offset)
-    Σ = sum_all_but(w,maxind) # Σ = ∑wₑ-1
-    log1p(Σ) + offset, Σ+1
-end
+# """
+#     logΣexp, Σexp = logsumexp!(p::WeightedParticles)
+# Return log(∑exp(w)). Modifies the weight vector to `w = exp(w-offset)`
+# Uses a numerically stable algorithm with offset to control for overflow and `log1p` to control for underflow. `Σexp` is the sum of the weifhts in the state they are left, i.e., `sum(exp.(w).-offset)`.
+#
+# References:
+# https://arxiv.org/pdf/1412.8695.pdf eq 3.8 for p(y)
+# https://discourse.julialang.org/t/fast-logsumexp/22827/7?u=baggepinnen for stable logsumexp
+# """
+# function logsumexp!(p::WeightedParticles)
+#     N = length(p)
+#     w = p.logweights
+#     offset, maxind = findmax(w)
+#     w .= exp.(w .- offset)
+#     Σ = sum_all_but(w,maxind) # Σ = ∑wₑ-1
+#     log1p(Σ) + offset, Σ+1
+# end
 
 """
     sum_all_but(w, i)
@@ -28,43 +28,43 @@ function sum_all_but(w,i)
     s
 end
 
-"""
-    loglik = resample!(p::WeightedParticles)
-Resample the particles based on the `p.logweights`. After a call to this function, weights will be reset to sum to one. Returns log-likelihood.
-"""
-function resample!(p::WeightedParticles)
-    N = length(p)
-    w = p.logweights
-    logΣexp,Σ = logsumexp!(p)
-    _resample!(p,Σ)
-    # fill!(p.weights, 1/N)
-    fill!(w, -log(N))
-    logΣexp - log(N)
-end
+# """
+#     loglik = resample!(p::WeightedParticles)
+# Resample the particles based on the `p.logweights`. After a call to this function, weights will be reset to sum to one. Returns log-likelihood.
+# """
+# function resample!(p::WeightedParticles)
+#     N = length(p)
+#     w = p.logweights
+#     logΣexp,Σ = logsumexp!(p)
+#     _resample!(p,Σ)
+#     # fill!(p.weights, 1/N)
+#     fill!(w, -log(N))
+#     logΣexp - log(N)
+# end
 
-"""
-In-place systematic resampling of `p`, returns the sum of weights.
-`p.logweights` should be exponentiated before calling this function.
-"""
-function _resample!(p::WeightedParticles,Σ)
-    x,w = p.particles, p.logweights
-    N = length(w)
-    bin = w[1]
-    s = rand()*Σ/N
-    bo = 1
-    for i = 1:N
-        @inbounds for b = bo:N
-            if s < bin
-                x[i] = x[b]
-                bo = b
-                break
-            end
-            bin += w[b+1] # should never reach here when b==N
-        end
-        s += Σ/N
-    end
-    Σ
-end
+# """
+# In-place systematic resampling of `p`, returns the sum of weights.
+# `p.logweights` should be exponentiated before calling this function.
+# """
+# function _resample!(p::WeightedParticles,Σ)
+#     x,w = p.particles, p.logweights
+#     N = length(w)
+#     bin = w[1]
+#     s = rand()*Σ/N
+#     bo = 1
+#     for i = 1:N
+#         @inbounds for b = bo:N
+#             if s < bin
+#                 x[i] = x[b]
+#                 bo = b
+#                 break
+#             end
+#             bin += w[b+1] # should never reach here when b==N
+#         end
+#         s += Σ/N
+#     end
+#     Σ
+# end
 
 """
     bootstrap(p::Particles)

--- a/src/types.jl
+++ b/src/types.jl
@@ -27,22 +27,7 @@ struct StaticParticles{T,N} <: AbstractParticles{T,N}
     particles::SArray{Tuple{N}, T, 1, N}
 end
 
-"""
-Particles with weights.
-To weight the particles `p`, modify the field `p.logweights`. You can resample the particles using `resample!(p)`, where each particles is resampled with a probability proportional to its weight.
-"""
-struct WeightedParticles{T,N} <: AbstractParticles{T,N}
-    particles::Vector{T}
-    # weights::Vector{T}
-    logweights::Vector{T}
-end
-function WeightedParticles{T,N}(v::AbstractVector) where {T,N}
-    # weights = fill(1/N, N)
-    logweights = fill(-log(N), N)
-    WeightedParticles{T,N}(v,logweights)
-end
 
 
 
 const MvParticles = Vector{<:AbstractParticles} # This can not be AbstractVector since it causes some methods below to be less specific than desired
-const MvWParticles = Vector{<:WeightedParticles}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ Random.seed!(0)
         @test [0,0] ∓ [1,1] isa MonteCarloMeasurements.MvParticles
 
         @info "Done"
-        for PT = (Particles, StaticParticles, WeightedParticles)
+        for PT = (Particles, StaticParticles)
             @testset "$(repr(PT))" begin
                 @info "Running tests for $PT"
                 p = PT(100)
@@ -117,7 +117,7 @@ Random.seed!(0)
                 @test f(p) ≲ 15
                 @test 5 ≲ f(p)
                 @test Normal(f(p)).μ ≈ mean(f(p))
-                !isa(p, WeightedParticles) && @test fit(Normal, f(p)).μ ≈ mean(f(p))
+                @test fit(Normal, f(p)).μ ≈ mean(f(p))
 
 
                 f = x -> x^2
@@ -164,11 +164,11 @@ Random.seed!(0)
 
 
     @time @testset "Multivariate Particles" begin
-        for PT = (Particles, StaticParticles, WeightedParticles)
+        for PT = (Particles, StaticParticles)
             @testset "$(repr(PT))" begin
                 @info "Running tests for multivariate $PT"
                 p = PT(100, MvNormal(2,1))
-                !isa(p,MonteCarloMeasurements.MvWParticles) && @test_nowarn sum(p)
+                @test_nowarn sum(p)
                 @test cov(p) ≈ I atol=0.6
                 @test mean(p) ≈ [0,0] atol=0.2
                 m = Matrix(p)
@@ -404,40 +404,6 @@ Random.seed!(0)
             popt = optimize(rosenbrock2d, deepcopy(p))
             popt ≈ [1,1]
         end
-    end
-
-    @time @testset "WeightedParticles" begin
-        @info "Testing weighted particles"
-        p = WeightedParticles(100)
-
-        # @test sum(p.weights) ≈ 1
-        @test sum(exp,p.logweights) ≈ 1
-        p.logweights .= randn.()
-        resample!(p)
-        # @test sum(p.weights) ≈ 1
-        @test sum(exp,p.logweights) ≈ 1
-        p = WeightedParticles(100)
-        p.logweights .+= logpdf.(Normal(0,1), 2 .-p.particles)
-        resample!(p)
-        @test mean(p) > 0
-        v = [WeightedParticles(1000), WeightedParticles(1000)]
-        @test cov(v) ≈ I atol=0.15
-        p = WeightedParticles(100)
-        p.logweights .= randn.()
-        log∑exp = log(sum(exp, p.logweights))
-        @test log∑exp ≈ MonteCarloMeasurements.logsumexp!(p)[1]
-        # Test numerical stability
-        p = WeightedParticles(2)
-        p.logweights .= [1e-20, log(1e-20)]
-        @test MonteCarloMeasurements.logsumexp!(p)[1] ≈ 2e-20
-
-        @test WeightedParticles(100) + WeightedParticles(randn(Float32, 100)) isa WeightedParticles{Float64,100}
-
-        p = WeightedParticles(100)
-        p.logweights .= randn.()
-        @test (p*p*p).logweights ≈ 3*p.logweights
-        msg = r"not yet fully supported for WeightedParticles"
-        @test_logs (:warn, msg) p+p
     end
 
 

--- a/test/test_forwarddiff.jl
+++ b/test/test_forwarddiff.jl
@@ -1,5 +1,4 @@
 using MonteCarloMeasurements, ForwardDiff, Test
-using MonteCarloMeasurements: ±
 const FD = ForwardDiff
 
 @testset "forwarddiff" begin


### PR DESCRIPTION
These were not well supported anyways and using them generated a lot of warnings of poor support. This PR removes them completely until someone needs them badly enough to implement proper support for them.