### PR TITLE
fix promotion of Particles with Missing

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -252,7 +252,7 @@ for PT in (:Particles, :StaticParticles, :WeightedParticles)
     @eval begin
         Base.length(::Type{$PT{T,N}}) where {T,N} = N
         Base.eltype(::Type{$PT{T,N}}) where {T,N} = $PT{T,N}
-        Base.promote_rule(::Type{S}, ::Type{$PT{T,N}}) where {S,T,N} = $PT{promote_type(S,T),N} # This is hard to hit due to method for real 3 lines down
+        Base.promote_rule(::Type{S}, ::Type{$PT{T,N}}) where {S<:Number,T,N} = $PT{promote_type(S,T),N} # This is hard to hit due to method for real 3 lines down
         Base.promote_rule(::Type{Bool}, ::Type{$PT{T,N}}) where {T,N} = $PT{promote_type(Bool,T),N} # Needed since above is not specific enough.
 
         Base.convert(::Type{StaticParticles{T,N}}, p::$PT{T,N}) where {T,N} = StaticParticles(p.particles)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -291,6 +291,7 @@ Random.seed!(0)
         @test promote_type(Particles{Float64,10}, Float64) == Particles{Float64,10}
         @test promote_type(Particles{Float64,10}, Int64) == Particles{Float64,10}
         @test promote_type(Particles{Float64,10}, ComplexF64) == Complex{Particles{Float64,10}}
+        @test promote_type(Particles{Float64,10}, Missing) == Union{Particles{Float64,10},Missing}
         @test convert(Float64, 0p) isa Float64
         @test convert(Float64, 0p) == 0
         @test convert(Int, 0p) isa Int


### PR DESCRIPTION
I ran into this problem, when constructing an array of particles with missing values. Right now, this throws an ambiguity error.