### PR TITLE
Add conversion from Particles to Array

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -322,8 +322,11 @@ Base.setindex!(p::AbstractParticles, val, i::Integer) = setindex!(p.particles, v
 Base.getindex(p::AbstractParticles, i::Integer) = getindex(p.particles, i)
 # Base.getindex(v::MvParticles, i::Int, j::Int) = v[j][i] # Defining this methods screws with show(::MvParticles)
 
+Base.Array(p::AbstractParticles) = p.particles
+Base.Vector(p::AbstractParticles) = Array(p)
+
 function Base.Array(v::Array{<:AbstractParticles})
-    m = reduce(hcat, getfield.(v,:particles))
+    m = reduce(hcat, Array.(v))
     return reshape(m, size(m, 1), size(v)...)
 end
 Base.Matrix(v::MvParticles) = Array(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,10 @@ Random.seed!(0)
                 @test p ≉ 2.1std(p)
                 @test !(p ≉ 1.9std(p))
 
+                v = randn(5)
+                @test Vector(PT(v)) == v
+                @test Array(PT(v)) == v
+
                 @testset "unsafe comparisons" begin
                     unsafe_comparisons(false)
                     @test_throws ErrorException p<p


### PR DESCRIPTION
This complements #41 and is useful for standardizing conversion of particles and arrays of particles to arrays (e.g. with outputs of Soss). Example usage:

```julia
julia> using MonteCarloMeasurements

julia> p = (x = Particles(randn(5)), y = Particles(randn(5,2)), z = Particles(randn(5, 2, 3)));

julia> typeof(p)
NamedTuple{(:x, :y, :z),Tuple{Particles{Float64,5},Array{Particles{Float64,5},1},Array{Particles{Float64,5},2}}}

julia> v = (; (k => Array(v) for (k, v) in pairs(p))...);

julia> typeof(v)
NamedTuple{(:x, :y, :z),Tuple{Array{Float64,1},Array{Float64,2},Array{Float64,3}}}

julia> size.(values(v))
((5,), (5, 2), (5, 2, 3))
```
