### PR TITLE
Add fallback method to ≲

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -415,7 +415,7 @@ Base.isinteger(p::AbstractParticles) = all(isinteger, p.particles)
 Base.iszero(p::AbstractParticles) = all(iszero, p.particles)
 Base.iszero(p::AbstractParticles, tol) = abs(mean(p.particles)) < tol
 
-
+≲(a,b,args...) = a < b
 ≲(a::Real,p::AbstractParticles,lim=2) = (mean(p)-a)/std(p) > lim
 ≲(p::AbstractParticles,a::Real,lim=2) = (a-mean(p))/std(p) > lim
 ≲(p::AbstractParticles,a::AbstractParticles,lim=2) = (mean(p)-mean(a))/(2sqrt(std(p)^2 + std(a)^2)) > lim

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,6 +120,8 @@ Random.seed!(0)
                 @test !(f(p) ≲ 11)
                 @test f(p) ≲ 15
                 @test 5 ≲ f(p)
+                @test 1 ≲ 2
+                
                 @test Normal(f(p)).μ ≈ mean(f(p))
                 !isa(p, WeightedParticles) && @test fit(Normal, f(p)).μ ≈ mean(f(p))
 


### PR DESCRIPTION
I added a fallback method 
```julia
≲(a,b,args...) = a < b
```
which basically just says that we treat numbers as `Particles` with `std == 0`. This fallback not existing bit me when I assumed I could do `sort!` in a dataframe using `lt=(≲)`. 