### PR TITLE
Sleefpirates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,8 @@ julia = "1.0"
 ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ControlSystems", "ForwardDiff", "Test", "Plots"]
+test = ["ControlSystems", "ForwardDiff", "SLEEFPirates", "Test", "Plots"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -341,3 +341,6 @@ The table below compares methods for uncertainty propagation with their parallel
 | Measurements.jl          | Extended Kalman filter  | Linearization          |
 | `Particles(sigmapoints)` | Unscented Kalman Filter | Unscented transform    |
 | `Particles`              | [Particle Filter](https://github.com/baggepinnen/LowLevelParticleFilters.jl)         | Monte Carlo (sampling) |
+
+## Faster `exp,log`
+If the user manually loads the library [SLEEFPirates.jl](https://github.com/chriselrod/SLEEFPirates.jl), some functions are overloaded for Particles of `Float64,Float32` eltypes making these functions 2-16 times faster depending on the processor SIMD width.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -331,7 +331,9 @@ t1 = @belapsed bode($G,$w)
 | Slowdown static vs. Measurements |  2.1x |
 | Slowdown sigma vs. Measurements |   0.9x|
 
-The benchmarks show that using `Particles` is much faster than doing the Monte-Carlo sampling manually. We also see that we're about 12 times slower than linear uncertainty propagation with Measurements.jl if we are using standard `Particles`, `StaticParticles` are within a factor of 2 of Measurements and `StaticParticles` with [`sigmapoints`](@ref) are actually 10% faster than Measurements (this is because 4 sigmapoints fit perfectly into the processors SIMD registers, making the extra calculations almost free).
+The benchmarks show that using `Particles` is much faster than doing the Monte-Carlo sampling manually. We also see that we're about 12 times slower than linear uncertainty propagation with Measurements.jl if we are using standard `Particles`, `StaticParticles` are within a factor of 2 of Measurements and `StaticParticles` with [`sigmapoints`](@ref) are actually 10% faster than Measurements (this is because 7 sigmapoints fit well into two of the processors SIMD registers, making the extra calculations very cheap).
+
+
 
 ## Comparison to nonlinear filtering
 The table below compares methods for uncertainty propagation with their parallel in nonlinear filtering.

--- a/examples/controlsystems.jl
+++ b/examples/controlsystems.jl
@@ -103,33 +103,37 @@ errorbarplot!(w,mag,0.01; scales..., subplot=3, lab="wtls")
 plot!(w,magG, subplot=3)
 
 ## bode benchmark =========================================
-using BenchmarkTools, Printf, ControlSystems
+using MonteCarloMeasurements, BenchmarkTools, Printf, ControlSystems
+
 w = exp10.(LinRange(-3,log10(π),30))
-p = 1 ± 0.1
+p = 1. ± 0.1
 ζ = 0.3 ± 0.1
-ω = 1 ± 0.1
+ω = 1. ± 0.1
 G = tf([p*ω], [1, 2ζ*ω, ω^2])
 t1 = @belapsed bode($G,$w)
-p = 1
+p = 1.
 ζ = 0.3
-ω = 1
-G = tf([p*ω], [1, 2ζ*ω, ω^2])
+ω = 1.
+G = tf([p*ω], [1., 2ζ*ω, ω^2])
+sleep(0.5)
 t2 = @belapsed bode($G,$w)
 using Measurements
-p = Measurements.:(±)(1, 0.1)
+p = Measurements.:(±)(1., 0.1)
 ζ = Measurements.:(±)(0.3, 0.1)
-ω = Measurements.:(±)(1, 0.1)
+ω = Measurements.:(±)(1., 0.1)
 G = tf([p*ω], [1, 2ζ*ω, ω^2])
+sleep(0.5)
 t3 = @belapsed bode($G,$w)
 
-p = 1 ∓ 0.1
+p = 1. ∓ 0.1
 ζ = 0.3 ∓ 0.1
-ω = 1 ∓ 0.1
+ω = 1. ∓ 0.1
 G = tf([p*ω], [1, 2ζ*ω, ω^2])
+sleep(0.5)
 t4 = @belapsed bode($G,$w)
-
 p,ζ,ω = StaticParticles(sigmapoints([1, 0.3, 1], 0.1^2))
 G = tf([p*ω], [1, 2ζ*ω, ω^2])
+sleep(0.5)
 t5 = @belapsed bode($G,$w)
 ##
 @printf("

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -93,6 +93,7 @@ LinearAlgebra.eigvals(p::Matrix{<:AbstractParticles}) = @bymap eigvals(p)
 
 function __init__()
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")
+    @require SLEEFPirates="476501e8-09a2-5ece-8869-fb82de89a1fa" include("sleefpirates.jl")
 end
 
 end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -17,9 +17,9 @@ See also [`±`](@ref), [`⊗`](@ref)
 ∓
 
 
-±(μ::Real,σ) = Particles{promote_type(typeof(μ),typeof(σ)),DEFAUL_NUM_PARTICLES}(systematic_sample(DEFAUL_NUM_PARTICLES,Normal(μ,σ); permute=true))
+±(μ::Real,σ) = Particles{promote_type(float(typeof(μ)),float(typeof(σ))),DEFAUL_NUM_PARTICLES}(systematic_sample(DEFAUL_NUM_PARTICLES,Normal(μ,σ); permute=true))
 ±(μ::AbstractVector,σ) = Particles(DEFAUL_NUM_PARTICLES, MvNormal(μ, σ))
-∓(μ::Real,σ) = StaticParticles{promote_type(typeof(μ),typeof(σ)),DEFAUL_STATIC_NUM_PARTICLES}(systematic_sample(DEFAUL_STATIC_NUM_PARTICLES,Normal(μ,σ); permute=true))
+∓(μ::Real,σ) = StaticParticles{promote_type(float(typeof(μ)),float(typeof(σ))),DEFAUL_STATIC_NUM_PARTICLES}(systematic_sample(DEFAUL_STATIC_NUM_PARTICLES,Normal(μ,σ); permute=true))
 ∓(μ::AbstractVector,σ) = StaticParticles(DEFAUL_STATIC_NUM_PARTICLES, MvNormal(μ, σ))
 
 """

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -17,9 +17,9 @@ See also [`±`](@ref), [`⊗`](@ref)
 ∓
 
 
-±(μ::Real,σ) = μ + σ*Particles(DEFAUL_NUM_PARTICLES)
+±(μ::Real,σ) = Particles{promote_type(typeof(μ),typeof(σ)),DEFAUL_NUM_PARTICLES}(systematic_sample(DEFAUL_NUM_PARTICLES,Normal(μ,σ); permute=true))
 ±(μ::AbstractVector,σ) = Particles(DEFAUL_NUM_PARTICLES, MvNormal(μ, σ))
-∓(μ::Real,σ) = μ + σ*StaticParticles(DEFAUL_STATIC_NUM_PARTICLES)
+∓(μ::Real,σ) = StaticParticles{promote_type(typeof(μ),typeof(σ)),DEFAUL_STATIC_NUM_PARTICLES}(systematic_sample(DEFAUL_STATIC_NUM_PARTICLES,Normal(μ,σ); permute=true))
 ∓(μ::AbstractVector,σ) = StaticParticles(DEFAUL_STATIC_NUM_PARTICLES, MvNormal(μ, σ))
 
 """

--- a/src/sigmapoints.jl
+++ b/src/sigmapoints.jl
@@ -35,7 +35,8 @@ p,ζ,ω = StaticParticles(sigmapoints([1, 0.3, 1], 0.1^2)) # Correct
 function sigmapoints(m, Σ::AbstractMatrix)
     n = length(m)
     X = sqrt(n*Σ)
-    [X; -X; zeros(1,n)] .+ m'
+    T = promote_type(eltype(m), eltype(X))
+    [X; -X; zeros(T,1,n)] .+ m'
 end
 
 sigmapoints(m, Σ::Number) = sigmapoints(m, diagm(0=>fill(Σ, length(m))))

--- a/src/sleefpirates.jl
+++ b/src/sleefpirates.jl
@@ -1,0 +1,27 @@
+
+for ff in (exp,)
+    f = nameof(ff)
+    m = Base.parentmodule(ff)
+    for PT in (:Particles, :StaticParticles)
+        eval(quote
+            function ($m.$f)(p::$PT{Float64,N}) where {Float64,N}
+                res = map((SLEEFPirates.$f), p.particles)
+                return $PT{Float64,N}(res)
+            end
+        end)
+    end
+end
+
+
+for ff in (exp,log)
+    f = nameof(ff)
+    m = Base.parentmodule(ff)
+    for PT in (:Particles, :StaticParticles)
+        eval(quote
+            function ($m.$f)(p::$PT{Float32,N}) where {Float32,N}
+                res = map((SLEEFPirates.$f), p.particles)
+                return $PT{Float32,N}(res)
+            end
+        end)
+    end
+end

--- a/src/sleefpirates.jl
+++ b/src/sleefpirates.jl
@@ -17,7 +17,7 @@ for ff in (exp,)
 end
 
 
-for ff in (log, sin, cos, tan, asin, acos, atan)
+for ff in (log, sin, cos, asin, acos, atan) # tan is not faster
     f = nameof(ff)
     fs = Symbol(f,"_fast")
     m = Base.parentmodule(ff)

--- a/src/sleefpirates.jl
+++ b/src/sleefpirates.jl
@@ -8,20 +8,29 @@ for ff in (exp,)
                 res = map((SLEEFPirates.$f), p.particles)
                 return $PT{Float64,N}(res)
             end
+            function ($m.$f)(p::$PT{Float32,N}) where {Float32,N}
+                res = map((SLEEFPirates.$f), p.particles)
+                return $PT{Float32,N}(res)
+            end
         end)
     end
 end
 
 
-for ff in (exp,log)
+for ff in (log, sin, cos, tan, asin, acos, atan)
     f = nameof(ff)
+    fs = Symbol(f,"_fast")
     m = Base.parentmodule(ff)
     for PT in (:Particles, :StaticParticles)
         eval(quote
-            function ($m.$f)(p::$PT{Float32,N}) where {Float32,N}
-                res = map((SLEEFPirates.$f), p.particles)
-                return $PT{Float32,N}(res)
-            end
+        function ($m.$f)(p::$PT{Float64,N}) where {Float64,N}
+            res = map((SLEEFPirates.$fs), p.particles)
+            return $PT{Float64,N}(res)
+        end
+        function ($m.$f)(p::$PT{Float32,N}) where {Float32,N}
+            res = map((SLEEFPirates.$fs), p.particles)
+            return $PT{Float32,N}(res)
+        end
         end)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -508,6 +508,7 @@ Random.seed!(0)
 
     include("test_forwarddiff.jl")
     include("test_deconstruct.jl")
+    include("test_sleefpirates.jl")
 
 end
 

--- a/test/test_sleefpirates.jl
+++ b/test/test_sleefpirates.jl
@@ -1,0 +1,8 @@
+using SLEEFPirates
+a = rand(500)
+@test map(exp, a) ≈ exp(Particles(a)).particles
+@test map(log, a) ≈ log(Particles(a)).particles
+
+a = rand(Float32, 500)
+@test map(exp, a) ≈ exp(Particles(a)).particles
+@test map(log, a) ≈ log(Particles(a)).particles

--- a/test/test_sleefpirates.jl
+++ b/test/test_sleefpirates.jl
@@ -2,7 +2,10 @@ using SLEEFPirates
 a = rand(500)
 @test map(exp, a) ≈ exp(Particles(a)).particles
 @test map(log, a) ≈ log(Particles(a)).particles
+@test map(cos, a) ≈ cos(Particles(a)).particles
+
 
 a = rand(Float32, 500)
 @test map(exp, a) ≈ exp(Particles(a)).particles
 @test map(log, a) ≈ log(Particles(a)).particles
+@test map(cos, a) ≈ cos(Particles(a)).particles


### PR DESCRIPTION
This PR adds some conditional overloads for Particles and the functions
- exp
- log
- Some trig funtions

if [SLEEFPirates](https://github.com/chriselrod/SLEEFPirates.jl) is loaded by the user. The result is speedups in the range of 1x-16x depending on the processor used. On my laptop, exp becomes about 2-6 times faster for Float64/Float32