### PR TITLE
Switch from map to broadcast

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MonteCarloMeasurements"
 uuid = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 authors = ["baggepinnen <baggepinnen@gmail.com>"]
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/examples/controlsystems.jl
+++ b/examples/controlsystems.jl
@@ -104,7 +104,8 @@ plot!(w,magG, subplot=3)
 
 ## bode benchmark =========================================
 using MonteCarloMeasurements, BenchmarkTools, Printf, ControlSystems
-
+using ChangePrecision
+@changeprecision Float32 begin
 w = exp10.(LinRange(-3,log10(π),30))
 p = 1. ± 0.1
 ζ = 0.3 ± 0.1
@@ -135,6 +136,7 @@ p,ζ,ω = StaticParticles(sigmapoints([1, 0.3, 1], 0.1^2))
 G = tf([p*ω], [1, 2ζ*ω, ω^2])
 sleep(0.5)
 t5 = @belapsed bode($G,$w)
+end
 ##
 @printf("
 | Benchmark | Result |

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -107,10 +107,10 @@ end
 
 
 # Two-argument functions
-foreach(register_primitive_multi, [+,-,*,/,//,^,
-max,min,mod,mod1,atan,atand,add_sum,hypot])
+# foreach(register_primitive_binop, [+,-,*,/,//,^])
+foreach(register_primitive_multi, [+,-,*,/,//,^,max,min,mod,mod1,atan,atand,add_sum,hypot])
 # One-argument functions
-foreach(register_primitive_single, [*,+,-,/,
+foreach(register_primitive_single, [+,-,
 exp,exp2,exp10,expm1,
 log,log10,log2,log1p,
 sin,cos,tan,sind,cosd,tand,sinh,cosh,tanh,

--- a/src/register_primitive.jl
+++ b/src/register_primitive.jl
@@ -19,6 +19,26 @@ Register a multi-argument function so that it works with particles. If you want 
 function register_primitive_multi(ff, eval=eval)
     f = nameof(ff)
     m = Base.parentmodule(ff)
+    # for PT in (:Particles, :StaticParticles)
+    #     eval(quote
+    #         function ($m.$f)(p::$PT{T,N},a::Real...) where {T,N}
+    #             res = ($m.$f).(p.particles, MonteCarloMeasurements.maybe_particles.(a)...) # maybe_particles introduced to handle >2 arg operators
+    #             return $PT{eltype(res),N}(res)
+    #         end
+    #         function ($m.$f)(a::Real,p::$PT{T,N}) where {T,N}
+    #             res = map(x->($m.$f)(a,x), p.particles)
+    #             return $PT{eltype(res),N}(res)
+    #         end
+    #         function ($m.$f)(p1::$PT{T,N},p2::$PT{T,N}) where {T,N}
+    #             res = map(($m.$f), p1.particles, p2.particles)
+    #             return $PT{eltype(res),N}(res)
+    #         end
+    #         function ($m.$f)(p1::$PT{T,N},p2::$PT{S,N}) where {T,S,N} # Needed for particles of different float types :/
+    #             res = map(($m.$f), p1.particles, p2.particles)
+    #             return $PT{eltype(res),N}(res)
+    #         end
+    #     end)
+    # end
     for PT in (:Particles, :StaticParticles)
         eval(quote
             function ($m.$f)(p::$PT{T,N},a::Real...) where {T,N}
@@ -26,15 +46,15 @@ function register_primitive_multi(ff, eval=eval)
                 return $PT{eltype(res),N}(res)
             end
             function ($m.$f)(a::Real,p::$PT{T,N}) where {T,N}
-                res = map(x->($m.$f)(a,x), p.particles)
+                res = ($m.$f).(a, p.particles)
                 return $PT{eltype(res),N}(res)
             end
             function ($m.$f)(p1::$PT{T,N},p2::$PT{T,N}) where {T,N}
-                res = map(($m.$f), p1.particles, p2.particles)
+                res = ($m.$f).(p1.particles, p2.particles)
                 return $PT{eltype(res),N}(res)
             end
             function ($m.$f)(p1::$PT{T,N},p2::$PT{S,N}) where {T,S,N} # Needed for particles of different float types :/
-                res = map(($m.$f), p1.particles, p2.particles)
+                res = ($m.$f).(p1.particles, p2.particles)
                 return $PT{eltype(res),N}(res)
             end
         end)
@@ -61,6 +81,31 @@ function register_primitive_multi(ff, eval=eval)
     end)
 end
 
+function register_primitive_binop(ff, eval=eval)
+    f = nameof(ff)
+    m = Base.parentmodule(ff)
+    for PT in (:Particles, :StaticParticles)
+        eval(quote
+            function ($m.$f)(p::$PT{T,N},a::Real...) where {T,N}
+                res = ($m.$f).(p.particles, MonteCarloMeasurements.maybe_particles.(a)...) # maybe_particles introduced to handle >2 arg operators
+                return $PT{eltype(res),N}(res)
+            end
+            function ($m.$f)(a::Real,p::$PT{T,N}) where {T,N}
+                res = ($m.$f).(a, p.particles)
+                return $PT{eltype(res),N}(res)
+            end
+            function ($m.$f)(p1::$PT{T,N},p2::$PT{T,N}) where {T,N}
+                res = ($m.$f).(p1.particles, p2.particles)
+                return $PT{eltype(res),N}(res)
+            end
+            function ($m.$f)(p1::$PT{T,N},p2::$PT{S,N}) where {T,S,N} # Needed for particles of different float types :/
+                res = ($m.$f).(p1.particles, p2.particles)
+                return $PT{eltype(res),N}(res)
+            end
+        end)
+    end
+end
+
 """
     register_primitive_single(ff, eval=eval)
 
@@ -72,7 +117,7 @@ function register_primitive_single(ff, eval=eval)
     for PT in (:Particles, :StaticParticles)
         eval(quote
             function ($m.$f)(p::$PT{T,N}) where {T,N}
-                res = map(($m.$f), p.particles)
+                res = ($m.$f).(p.particles)
                 return $PT{eltype(res),N}(res)
             end
         end)

--- a/src/register_primitive.jl
+++ b/src/register_primitive.jl
@@ -81,31 +81,6 @@ function register_primitive_multi(ff, eval=eval)
     end)
 end
 
-function register_primitive_binop(ff, eval=eval)
-    f = nameof(ff)
-    m = Base.parentmodule(ff)
-    for PT in (:Particles, :StaticParticles)
-        eval(quote
-            function ($m.$f)(p::$PT{T,N},a::Real...) where {T,N}
-                res = ($m.$f).(p.particles, MonteCarloMeasurements.maybe_particles.(a)...) # maybe_particles introduced to handle >2 arg operators
-                return $PT{eltype(res),N}(res)
-            end
-            function ($m.$f)(a::Real,p::$PT{T,N}) where {T,N}
-                res = ($m.$f).(a, p.particles)
-                return $PT{eltype(res),N}(res)
-            end
-            function ($m.$f)(p1::$PT{T,N},p2::$PT{T,N}) where {T,N}
-                res = ($m.$f).(p1.particles, p2.particles)
-                return $PT{eltype(res),N}(res)
-            end
-            function ($m.$f)(p1::$PT{T,N},p2::$PT{S,N}) where {T,S,N} # Needed for particles of different float types :/
-                res = ($m.$f).(p1.particles, p2.particles)
-                return $PT{eltype(res),N}(res)
-            end
-        end)
-    end
-end
-
 """
     register_primitive_single(ff, eval=eval)
 


### PR DESCRIPTION
This switches from using `map` on particles to using broadcast. There seems to be quite the performance difference between the two
```julia
a = rand(Float32, 500)
b = rand(Float32, 500)
@btime(map(max,$a, b), samples=100000, setup=(b = (rand(Float32, 500))))
@btime(vmap(max,$a,b), samples=100000, setup=(b = (rand(Float32, 500))))
@btime max.($a , $b) samples=100000
  1.681 μs (4 allocations: 2.19 KiB)
  460.893 ns (1 allocation: 2.13 KiB)
  619.917 ns (1 allocation: 2.13 KiB)
```