### PR TITLE
Remove GenericLinearAlgebra dep.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,11 @@
 name = "MonteCarloMeasurements"
 uuid = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 authors = ["baggepinnen <baggepinnen@gmail.com>"]
-version = "0.8.9"
+version = "0.9.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -29,6 +28,7 @@ julia = "1.0"
 
 [extras]
 ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
+GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -36,4 +36,4 @@ SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ControlSystems", "ForwardDiff", "Measurements", "SLEEFPirates", "Test", "Plots"]
+test = ["ControlSystems", "GenericLinearAlgebra", "ForwardDiff", "Measurements", "SLEEFPirates", "Test", "Plots"]

--- a/examples/controlsystems.jl
+++ b/examples/controlsystems.jl
@@ -1,6 +1,6 @@
 # # ControlSystems using MonteCarloMeasurements
 # In this example, we will create a transfer function with uncretain coefficients, and use it to calculate bode diagrams and simulate the system.
-using ControlSystems, MonteCarloMeasurements, StatsPlots
+using ControlSystems, MonteCarloMeasurements, StatsPlots, GenericLinearAlgebra
 using Test, LinearAlgebra, Statistics
 import MonteCarloMeasurements: ⊗
 unsafe_comparisons(true, verbose=false) # This file requires mean comparisons for displaying transfer functions in text form as well as for discretizing a LTIsystem

--- a/src/MonteCarloMeasurements.jl
+++ b/src/MonteCarloMeasurements.jl
@@ -1,5 +1,5 @@
 module MonteCarloMeasurements
-using LinearAlgebra, Statistics, Random, StaticArrays, RecipesBase, GenericLinearAlgebra, MacroTools
+using LinearAlgebra, Statistics, Random, StaticArrays, RecipesBase, MacroTools
 using Distributed: pmap
 import Base: add_sum
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 @info "Running tests"
-using MonteCarloMeasurements, Distributions
+using MonteCarloMeasurements, Distributions, GenericLinearAlgebra
 using Test, LinearAlgebra, Statistics, Random
 import MonteCarloMeasurements: ⊗, gradient, optimize, DEFAULT_NUM_PARTICLES
 @info "import Plots"


### PR DESCRIPTION
GLA causes warnings due to type piracy of the same functions as GenericSVD