### PR TITLE
fix complex bug

### DIFF
--- a/src/complex.jl
+++ b/src/complex.jl
@@ -79,7 +79,7 @@ Base.isfinite(p::Complex{<: AbstractParticles}) = isfinite(real(p)) && isfinite(
 
 function Base.:(/)(a::Complex{T}, b::Complex{T}) where T<:AbstractParticles
     are = real(a); aim = imag(a); bre = real(b); bim = imag(b)
-    if mean(abs(bre)) <= mean(abs(bim))
+    if pmean(abs(bre)) <= pmean(abs(bim))
         if isinf(bre) && isinf(bim)
             r = sign(bre)/sign(bim)
         else
@@ -100,7 +100,7 @@ end
 
 function Base.:(/)(are::T, b::Complex{T}) where T<:AbstractParticles
     aim = 0; bre = real(b); bim = imag(b)
-    if mean(abs(bre)) <= mean(abs(bim))
+    if pmean(abs(bre)) <= pmean(abs(bim))
         if isinf(bre) && isinf(bim)
             r = sign(bre)/sign(bim)
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -510,6 +510,7 @@ Random.seed!(0)
         z = complex(1 ± 0.1, 1 ± 0.1)
         @unsafe @test abs(sqrt(z ^ 2) - z) < eps()
         @unsafe @test abs(sqrt(z ^ 2.0) - z) < eps()
+        @test z/z ≈ 1
 
         z = complex(1 ± 0.1, 0 ± 0.1)
         @test real(2 ^ z) ≈ 2 ^ real(z)


### PR DESCRIPTION
The latest release tripped a test in our package. The following errors, and I would think that it should not:
```
julia> z = complex(1 ± 0.1, 1 ± 0.1);
julia> z/z
ERROR: Comparison of uncertain values using comparison mode safe failed. Comparison operators are not well defined for uncertain values. Call `unsafe_comparisons(true)` to enable comparison operators for particles using the current reduction function pmean. Change this function using `set_comparison_function(f)`. For safety reasons, the default safe comparison function is maximally conservative and tests if the extreme values of the distributions fulfil the comparison operator.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] _comparison_error()
   @ MonteCarloMeasurements ~/git/MonteCarloMeasurements.jl/src/particles.jl:511
 [3] safe_comparison(a_::Particles{Float64, 2000}, b_::Particles{Float64, 2000}, op::typeof(<=))
   @ MonteCarloMeasurements ~/git/MonteCarloMeasurements.jl/src/particles.jl:485
 [4] do_comparison(a::Particles{Float64, 2000}, b::Particles{Float64, 2000}, op::typeof(<=))
   @ MonteCarloMeasurements ~/git/MonteCarloMeasurements.jl/src/particles.jl:497
 [5] <=
   @ ~/git/MonteCarloMeasurements.jl/src/particles.jl:524 [inlined]
 [6] /(a::Complex{Particles{Float64, 2000}}, b::Complex{Particles{Float64, 2000}})
   @ MonteCarloMeasurements ~/git/MonteCarloMeasurements.jl/src/complex.jl:82
 [7] top-level scope
   @ none:1
```
This PR is an attempt to fix what looks like a bug. I also added a test that trips without the fix.

I hope this is useful. Please let me know if I misunderstood something.
