### PR TITLE
define `float` for particles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MonteCarloMeasurements"
 uuid = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 authors = ["baggepinnen <baggepinnen@gmail.com>"]
-version = "1.0.11"
+version = "1.0.12"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -186,7 +186,7 @@ exp,exp2,exp10,expm1,
 log,log10,log2,log1p,
 sin,cos,tan,sind,cosd,tand,sinh,cosh,tanh,
 asin,acos,atan,asind,acosd,atand,asinh,acosh,atanh,
-zero,sign,abs,sqrt,rad2deg,deg2rad])
+zero,sign,abs,sqrt,rad2deg,deg2rad,float])
 
 MvParticles(x::AbstractVector{<:AbstractArray{<:Number}}) = Particles(copy(reduce(hcat, x)'))
 MvParticles(v::AbstractVector{<:Number}) = Particles(v)


### PR DESCRIPTION
This appears to be required for a lot of numerical codes that use `float` defensively to promote Ints to floats etc.