### PR TITLE
make to1series optional

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -208,23 +208,23 @@ end
 
 @recipe function plt(x::AbstractArray, y::Union{MvParticles,AbstractMatrix{<:AbstractParticles}}, q=0.025; N=true, ri=true, quantile=nothing)
     samedim = size(x) === size(y)
-    layout --> max(size(x, 2), size(y, 2))
+    # layout --> max(size(x, 2), size(y, 2))
     q = quantile === nothing ? q : quantile
     if N > 0
         for col = 1:size(y,2)
             yc = y[:,col]
             if ri
                 @series begin
-                    seriescolor --> col
-                    subplot --> col
+                    # seriescolor --> col
+                    # subplot --> col
                     ribbon := quantiles(yc, q)
                     label --> "Mean with ($q, $(1-q)) quantiles"
                     x, pmean.(yc)
                 end
             end
             @series begin
-                seriescolor --> col
-                subplot --> col
+                # seriescolor --> col
+                # subplot --> col
                 M = Matrix(yc)
                 np,ny = size(M)
                 primary := !ri

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -59,8 +59,9 @@ end
 to1series(y) = to1series(1:size(y,1),y)
 
 @userplot MCplot
-@recipe function plt(p::MCplot)
+@recipe function plt(p::MCplot; oneseries=true)
     x,y,q = handle_args(p)
+    to1series = oneseries ? MonteCarloMeasurements.to1series : (x,y) -> (x,y)
     N = nparticles(y)
     selected = q > 1 ? randperm(N)[1:q] : 1:N
     N = length(selected)
@@ -78,9 +79,10 @@ to1series(y) = to1series(1:size(y,1),y)
 end
 
 @userplot Ribbonplot
-@recipe function plt(p::Ribbonplot; N=false, quantile=nothing)
+@recipe function plt(p::Ribbonplot; N=false, quantile=nothing, oneseries=true)
     x,y,q = handle_args(p)
     q = quantile === nothing ? q : quantile
+    to1series = oneseries ? MonteCarloMeasurements.to1series : identity
     if N > 0
         for col = 1:size(y,2)
             yc = y[:,col]
@@ -141,9 +143,10 @@ ribbonplot
 
 
 
-@recipe function plt(y::Union{MvParticles,AbstractMatrix{<:AbstractParticles}}, q=0.025; N=true, ri=true, quantile=nothing)
+@recipe function plt(y::Union{MvParticles,AbstractMatrix{<:AbstractParticles}}, q=0.025; N=true, ri=true, quantile=nothing, oneseries=true)
     q = quantile === nothing ? q : quantile
     label --> "Mean with ($q, $(1-q)) quantiles"
+    to1series = oneseries ? MonteCarloMeasurements.to1series : identity
     for col = 1:size(y,2)
         yc = y[:,col]
         if ri
@@ -206,10 +209,11 @@ end
     mx, y
 end
 
-@recipe function plt(x::AbstractArray, y::Union{MvParticles,AbstractMatrix{<:AbstractParticles}}, q=0.025; N=true, ri=true, quantile=nothing)
+@recipe function plt(x::AbstractArray, y::Union{MvParticles,AbstractMatrix{<:AbstractParticles}}, q=0.025; N=true, ri=true, quantile=nothing, oneseries=true)
     samedim = size(x) === size(y)
     # layout --> max(size(x, 2), size(y, 2))
     q = quantile === nothing ? q : quantile
+    to1series = oneseries ? MonteCarloMeasurements.to1series : (x,y) -> (x,y)
     if N > 0
         for col = 1:size(y,2)
             yc = y[:,col]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -598,10 +598,11 @@ Random.seed!(0)
         @info "Testing plotting"
         p = Particles(100)
         v = randn(3) .+ Particles.(10)
-        M = randn(3,2) .+ Particles.(10)
+        M = randn(3,2) .+ [-1 1] .+ Particles.(10)
         @test_nowarn Plots.plot(p)
         @test_nowarn Plots.plot(v)
         @test_nowarn Plots.plot(M)
+        @test_nowarn Plots.plot(M .+ 5) # This plot should have 4 different colored bands
         @test_nowarn Plots.plot(v, ri=false)
         @test_nowarn Plots.plot(v, N=0)
         @test_nowarn Plots.plot(M, N=0)
@@ -616,10 +617,15 @@ Random.seed!(0)
         @test_nowarn Plots.plot(1:3,v, ri=false)
         @test_nowarn Plots.plot(1:3, v, N=5)
         @test_nowarn Plots.plot(1:3, M, N=5)
+        @test_nowarn Plots.plot!(1:3, M .+ 5, N=5) # This plot should have 4 different colored bands
         @test_nowarn Plots.plot((1:3) .* [1 1], M, N=10)
+
+        @test_nowarn Plots.plot(1:3, M, N=5, ri=false)
+        @test_nowarn Plots.plot!(1:3, M .+ 5, N=5, ri=false) # This plot should have 4 different colored mclines
 
         @test_nowarn Plots.plot(1:3, v, N=0)
         @test_nowarn Plots.plot(1:3, M, N=0)
+        @test_nowarn Plots.plot!(1:3, M .+ 5, N=0) # This plot should have 4 different colored bands
         @test_nowarn Plots.plot((1:3) .* [1 1], M, N=0)
 
         @test_nowarn errorbarplot(1:3,v)


### PR DESCRIPTION
This PR allows to plot different traces as different series by providing `oneseries = false` to plot functions.