### PR TITLE
Allow printing of arbitrary Particles

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -101,7 +101,7 @@ Return a short string describing the type
 """
 shortform(p::Particles) = "Part"
 shortform(p::StaticParticles) = "SPart"
-function to_num_str(p::AbstractParticles{T}, d=3, ds=d-1) where T
+function to_num_str(p::AbstractParticles{T}, d=3, ds=d-1) where {T<:Union{Number,AbstractArray}}
     s = pstd(p)
     # TODO: be smart and select sig digits based on s
     if T <: AbstractFloat && s < eps(p)
@@ -110,6 +110,7 @@ function to_num_str(p::AbstractParticles{T}, d=3, ds=d-1) where T
         string(round(pmean(p), sigdigits=d), " ± ", round(s, sigdigits=ds))
     end
 end
+to_num_str(p::AbstractParticles{T}, d, ds) where T = ""
 
 
 function Base.show(io::IO, p::AbstractParticles{T,N}) where {T,N}


### PR DESCRIPTION
At the moment, printing errors for particles that don't have a number- or array-like type (which allows `pstd`):

```julia
julia> using MonteCarloMeasurements

julia> Particles(["a", "b"])
Error showing value of type Particles{String, 2}:
ERROR: MethodError: no method matching /(::String, ::Int64)

Closest candidates are:
  /(::BigFloat, ::Union{Int16, Int32, Int64, Int8})
   @ Base mpfr.jl:494
  /(::Missing, ::Number)
   @ Base missing.jl:123
  /(::BigInt, ::Union{Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8})
   @ Base gmp.jl:565
  ...

Stacktrace:
  [1] _mean(f::typeof(identity), A::Vector{String}, dims::Colon)
    @ Statistics ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:186
  [2] mean(A::Vector{String}; dims::Function)
    @ Statistics ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:174
  [3] _var(A::Vector{String}, corrected::Bool, mean::Nothing, ::Colon)
    @ Statistics ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:389
  [4] var(A::Vector{String}; corrected::Bool, mean::Nothing, dims::Function)
    @ Statistics ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:378
  [5] _std(A::Vector{String}, corrected::Bool, mean::Nothing, ::Colon)
    @ Statistics ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:464
  [6] std(A::Vector{String}; corrected::Bool, mean::Nothing, dims::Function)
    @ Statistics ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:459
  [7] pstd(::Particles{String, 2}; kwargs::@Kwargs{})
    @ MonteCarloMeasurements ~/.julia/packages/MonteCarloMeasurements/dQJTj/src/particles.jl:310
  [8] pstd(::Particles{String, 2})
    @ MonteCarloMeasurements ~/.julia/packages/MonteCarloMeasurements/dQJTj/src/particles.jl:308
  [9] to_num_str(p::Particles{String, 2}, d::Int64, ds::Int64)
    @ MonteCarloMeasurements ~/.julia/packages/MonteCarloMeasurements/dQJTj/src/particles.jl:105
 [10] show(io::IOContext{Base.TTY}, ::MIME{Symbol("text/plain")}, p::Particles{String, 2})
    @ MonteCarloMeasurements ~/.julia/packages/MonteCarloMeasurements/dQJTj/src/particles.jl:0
 [11] (::OhMyREPL.var"#15#16"{REPL.REPLDisplay{…}, MIME{…}, Base.RefValue{…}})(io::IOContext{Base.TTY})
    @ OhMyREPL ~/.julia/packages/OhMyREPL/gPPKm/src/output_prompt_overwrite.jl:23
 [12] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [13] display
    @ ~/.julia/packages/OhMyREPL/gPPKm/src/output_prompt_overwrite.jl:6 [inlined]
 [14] display
    @ ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:278 [inlined]
 [15] display(x::Any)
    @ Base.Multimedia ./multimedia.jl:340
 [16] #invokelatest#2
    @ ./essentials.jl:892 [inlined]
 [17] invokelatest
    @ ./essentials.jl:889 [inlined]
 [18] print_response(errio::IO, response::Any, show_value::Bool, have_color::Bool, specialdisplay::Union{…})
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:315
 [19] (::REPL.var"#57#58"{REPL.LineEditREPL, Pair{Any, Bool}, Bool, Bool})(io::Any)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:284
 [20] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [21] print_response(repl::REPL.AbstractREPL, response::Any, show_value::Bool, have_color::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:282
 [22] (::REPL.var"#do_respond#80"{…})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:911
 [23] #invokelatest#2
    @ ./essentials.jl:892 [inlined]
 [24] invokelatest
    @ ./essentials.jl:889 [inlined]
 [25] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/LineEdit.jl:2656
 [26] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1312
 [27] (::REPL.var"#62#68"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:386
Some type information was truncated. Use `show(err)` to see complete types.
```

This PR allows a nicer behavior:

```julia
julia> using MonteCarloMeasurements

julia> Particles(["a", "b"])
 Particles{String, 2}
```