### PR TITLE
add literal_pow overload

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -380,7 +380,7 @@ for PT in ParticleSymbols
             $PT{eltype(res),N}(res)
         end
 
-        function Base.literal_pow(::typeof(^), p::$PT, ::Val{i}) where {i}
+        function Base.literal_pow(::typeof(^), p::$PT{T,N}, ::Val{i}) where {T,N,i}
             res = Base.literal_pow.(^, p.particles, Val(i))
             $PT{eltype(res),N}(res)
         end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -379,6 +379,12 @@ for PT in ParticleSymbols
             res = p.particles.^i
             $PT{eltype(res),N}(res)
         end
+
+        function Base.literal_pow(::typeof(^), p::$PT, ::Val{i}) where {i}
+            res = Base.literal_pow.(^, x.particles, Val(i))
+            $PT{eltype(res),N}(res)
+        end
+
         Base.:\(p::Vector{<:$PT}, p2::Vector{<:$PT}) = Matrix(p)\Matrix(p2) # Must be here to be most specific
 
         function LinearAlgebra.eigvals(p::Matrix{$PT{T,N}}; kwargs...) where {T,N} # Special case to propte types differently

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -381,7 +381,7 @@ for PT in ParticleSymbols
         end
 
         function Base.literal_pow(::typeof(^), p::$PT, ::Val{i}) where {i}
-            res = Base.literal_pow.(^, x.particles, Val(i))
+            res = Base.literal_pow.(^, p.particles, Val(i))
             $PT{eltype(res),N}(res)
         end
 


### PR DESCRIPTION
Mostly for performance:
```julia
f(x) = x^2

x = Particles()
xu = x*u"km"

@b f(x)  # goes from a few mus to hundreds of ns
@b f(xu)  # goes from a few ms (!) to hundreds of ns
```