### PR TITLE
fix convert() between Particles types

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -330,7 +330,7 @@ for PT in ParticleSymbols
 
         Base.convert(::Type{StaticParticles{T,N}}, p::$PT{T,N}) where {T,N} = StaticParticles(p.particles)
         Base.convert(::Type{$PT{T,N}}, f::Real) where {T,N} = $PT{T,N}(fill(T(f),N))
-        Base.convert(::Type{$PT{T,N}}, f::$PT{S,N}) where {T,N,S} = $PT{promote_type(T,S),N}(convert.(promote_type(T,S),f.particles))
+        Base.convert(::Type{$PT{T,N}}, f::$PT{S,N}) where {T,N,S} = $PT{T,N}(convert.(T,f.particles))
         function Base.convert(::Type{S}, p::$PT{T,N}) where {S<:ConcreteFloat,T,N}
             N == 1 && (return S(p.particles[1]))
             pstd(p) < eps(S) || throw(ArgumentError("Cannot convert a particle distribution to a float if not all particles are the same."))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,6 +456,7 @@ Random.seed!(0)
         @test convert(Int, 0p) isa Int
         @test convert(Int, 0p) == 0
         @test convert(Particles{Float64,100}, Particles(randn(Float32, 100))) isa Particles{Float64,100}
+        @test convert(Particles{Float32,100}, Particles(randn(Float64, 100))) isa Particles{Float32,100}
         @test_throws ArgumentError convert(Int, p)
         @test_throws ArgumentError AbstractFloat(p)
         @test AbstractFloat(0p) == 0.0


### PR DESCRIPTION
convert(T) should always return T in Julia, instead of doing promotions